### PR TITLE
Update of zsh completion

### DIFF
--- a/completion/_catkin
+++ b/completion/_catkin
@@ -25,7 +25,6 @@ local _workspace_root
 local _workspace_profiles
 local _workspace_source_space
 local _enclosing_package
-local _getting_packages
 
 _workspace_root_hint="$PWD"
 
@@ -36,12 +35,8 @@ function _debug_log() {
   fi
 }
 
-# Get the workspace root (if available)
-_catkin_get_enclosing_workspace() {
-  if [[ -n "$_workspace_root" ]]; then
-    return 0
-  fi
-
+# Get the workspace root by following the specified path
+_catkin_find_enclosing_workspace_for_path() {
   local _path
   _path="$1"
 
@@ -56,6 +51,30 @@ _catkin_get_enclosing_workspace() {
       _path="$(dirname "$_path")"
     fi
   done
+
+  return 1
+}
+
+# Get the workspace root (if available)
+_catkin_get_enclosing_workspace() {
+  if [[ -n "$_workspace_root" ]]; then
+    return 0
+  fi
+
+  _debug_log "Search for workspace root in resolved path:"
+  _catkin_find_enclosing_workspace_for_path $(readlink -f "$1")
+
+  if [[ -n "$_workspace_root" ]]; then
+    return 0
+  fi
+
+  # search for workspace root in real path
+  _debug_log "Search for workspace root in real path:"
+  _catkin_find_enclosing_workspace_for_path $1
+
+  if [[ -n "$_workspace_root" ]]; then
+    return 0
+  fi
 
   return 1
 }
@@ -119,7 +138,6 @@ _catkin_get_packages() {
 
   # Get the workspace root
   _catkin_get_enclosing_workspace $_workspace_root_hint
-
 
   if [[ "$?" -ne 0 ]]; then
     _debug_log "Couldn't get workspace root!"

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -156,13 +156,20 @@ _catkin_get_packages() {
     zstyle ":completion:${curcontext}:" cache-policy _catkin_packages_caching_policy
   fi
 
-  # If cache is invalid or if the package list is not set yet and can't be retrieved from cache regenerate cache
+  # If cache is invalid, or if the package list or workspace cache file path are not set yet or this path differ from 
+  # its located path (we switched to different workspace) and variables can't be retrieved from cache regenerate cache
   # ( Remember that _retrieve_cache returns 0 if everything's fine, 1 if not. _cache_invalid returns 0 if cache needs rebuilding, 1 otherwise)
   # (see https://unix.stackexchange.com/q/588662 for the use of parentheses)
-  if _cache_invalid workspace_packages || { [[ ${+_workspace_packages} -eq 0 ]] && ! _retrieve_cache workspace_packages }; then
+  if _cache_invalid workspace_packages || \
+    {{ [[ ${+_workspace_packages} -eq 0 ]] || 
+      [[ -z "$_workspace_cache_file_path" ]] ||  
+      [[ "$_workspace_cache_file_path" != "$cache_file_path" ]] } && 
+      ! _retrieve_cache workspace_packages } ; then
+
     _debug_log "Regenerating package cache because retrieval failed ..."
     _workspace_packages=(${${(f)"$(catkin list -u --quiet)"}})
-    _store_cache workspace_packages _workspace_packages
+    _workspace_cache_file_path=$cache_file_path
+    _store_cache workspace_packages _workspace_packages _workspace_cache_file_path
   fi
 
   local expl

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -68,7 +68,6 @@ _catkin_get_enclosing_workspace() {
     return 0
   fi
 
-  # search for workspace root in real path
   _debug_log "Search for workspace root in real path:"
   _catkin_find_enclosing_workspace_for_path $1
 

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -53,7 +53,7 @@ _catkin_get_enclosing_workspace() {
       _workspace_root=$_path
       return 0
     else
-      _path="$(readlink -f $_path/..)"
+      _path="$(dirname "$_path")"
     fi
   done
 
@@ -78,7 +78,7 @@ _catkin_get_enclosing_package() {
       _enclosing_package="$(xmllint --xpath '/package/name/text()' "$_path/package.xml")"
       return 0
     else
-      _path="$(readlink -f $_path/..)"
+      _path="$(dirname "$_path")"
     fi
   done
 
@@ -283,6 +283,8 @@ _catkin_config_complete() {
     '(-b --build-space)--default-build-space[Use the default path to the build space]'\
     '(--default-install-space)'{-i,--install-space}'[Install space path]'\
     '(-i --install-space)--default-install-space[Use the default path to the install space]'\
+    '(--default-log-space)'{-L,--log-space}'[Log space path]'\
+    '(-L --log-space)--default-log-space[Use the default path to the log space]'\
     {-x,--space-suffix}'[Suffix for build, devel, and install spaces]:suffix:()'\
     '(--link-devel --isolate-devel)--merge-devel[Build products directly into a merged devel space]'\
     '(--merge-devel --isolate-devel)--link-devel[Symbolically link products into a merged devel space]'\
@@ -293,6 +295,7 @@ _catkin_config_complete() {
     '(--isolate-install)--merge-install[Install each catkin package into a single merged install space]'\
     {-j,--jobs}'[Maximum number of build jobs to be distributed across active packages]:JOBS:()'\
     {-p,--parallel-packages}'[Maximum number of packages allowed to be built in parallel]:PACKAGE_JOBS:()'\
+    {-l,--load-average}'[Maximum load average before no new build jobs are scheduled]'\
     '(--no-jobserver)--jobserver[Use the internal GNU Make job server]'\
     '(--jobserver)--no-jobserver[Disable the internal GNU Make job server]'\
     '(--no-env-cache)--env-cache[Re-use cached environment variables]'\
@@ -500,11 +503,13 @@ case "$state" in
           _describe -t terminators "terminate multiword argument" terminating_opts
         elif ((${words[1,$CURRENT-1][(I)--make-args]} > ${words[1,$CURRENT-1][(I)--]} && ${words[1,$CURRENT-1][(I)--make-args]} >= ${words[1,$CURRENT-1][(I)--*make-args]} && ${words[1,$CURRENT-1][(I)--make-args]} > ${words[1,$CURRENT-1][(I)--(black|white)list]})); then
           # same as above, just for make
+          _debug_log "make"
           _dispatch $service make
           _describe -t terminators "terminate multiword argument" terminating_opts
         elif ((${words[1,$CURRENT-1][(I)--catkin-make-args]} > ${words[1,$CURRENT-1][(I)--]} && ${words[1,$CURRENT-1][(I)--catkin-make-args]} >= ${words[1,$CURRENT-1][(I)--*make-args]} && ${words[1,$CURRENT-1][(I)--catkin-make-args]} > ${words[1,$CURRENT-1][(I)--(black|white)list]})); then
-          # same as above, just for catkin-make
-          # TODO implement
+          # same as above, just for catkin_make
+          _debug_log "catkin_make"
+          _dispatch $service catkin_make
           _describe -t terminators "terminate multiword argument" terminating_opts
         else
           _debug_log "normal"


### PR DESCRIPTION
- Add missing arguments for zsh completion according the suggestions in your pull request (https://github.com/catkin/catkin_tools/pull/609)
- change search for parent folder using '**readlink -f**' to '**dirname**' which works also for symlinked packages in workspace